### PR TITLE
Use proper error method

### DIFF
--- a/api/services/NotificationService.js
+++ b/api/services/NotificationService.js
@@ -95,7 +95,7 @@ module.exports = {
       try {
         responseData = JSON.parse(body);
       } catch (error) {
-        sails.services.logservice.error('Got invalid JSON format from endpoint.', error, body);
+        sails.services.logservice.logErrors('Got invalid JSON format from endpoint.', error, body);
         responseData = null;
       }
 


### PR DESCRIPTION
Error is triggerd when the json response of the wallet can't be parsed while sending an notification